### PR TITLE
Change Marauder regen value for vanilla

### DIFF
--- a/src/game/tremulous.h
+++ b/src/game/tremulous.h
@@ -191,8 +191,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define LEVEL2_SPEED                1.35f
 #define LEVEL2_VALUE                AVM(420)
-#define LEVEL2_HEALTH               AHM(150000)
-#define LEVEL2_REGEN                (0.03f * LEVEL2_HEALTH)
+#define LEVEL2_HEALTH               AHM(100000)
+#define LEVEL2_REGEN                (0.04f * LEVEL2_HEALTH)
 #define LEVEL2_COST                 1
 
 #define LEVEL2_UPG_SPEED            1.35f

--- a/src/game/tremulous.h
+++ b/src/game/tremulous.h
@@ -191,8 +191,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define LEVEL2_SPEED                1.35f
 #define LEVEL2_VALUE                AVM(420)
-#define LEVEL2_HEALTH               AHM(100000)
-#define LEVEL2_REGEN                (0.04f * LEVEL2_HEALTH)
+#define LEVEL2_HEALTH               AHM(150000)
+#define LEVEL2_REGEN                4000.0
 #define LEVEL2_COST                 1
 
 #define LEVEL2_UPG_SPEED            1.35f


### PR DESCRIPTION
From Chocolate value (4.5) to 4.0.
Closes #98